### PR TITLE
ci: re-enable releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ jobs:
 
     - stage: build
       script: yarn build
-#    - stage: release
-#      # only run on master branch
-#      if: NOT type = pull_request AND branch = master
-#      script: yarn release
+
+    - stage: release
+      # only run on master branch
+      if: NOT type = pull_request AND branch = master
+      script: yarn release


### PR DESCRIPTION
Re-enables Lerna releases after the redesign in #59, as a follow-up on #58.