### PR TITLE
revert: "ci: re-enable releases (#60)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,7 @@ jobs:
 
     - stage: build
       script: yarn build
-
-    - stage: release
-      # only run on master branch
-      if: NOT type = pull_request AND branch = master
-      script: yarn release
+#    - stage: release
+#      # only run on master branch
+#      if: NOT type = pull_request AND branch = master
+#      script: yarn release


### PR DESCRIPTION
This reverts commit 8a5e859cb67122d0c0366af4b99601763ba0c268.

The Lerna release pipeline is broken. I will switch to manual release for now, while I look for a solution. Any suggestions are welcome!