### PR TITLE
fix: ignore node_modules in the starter

### DIFF
--- a/examples/gatsby-starter-oss/.gitignore
+++ b/examples/gatsby-starter-oss/.gitignore
@@ -1,0 +1,3 @@
+# ignore node_modules while the publish-starter action doesn't pull .gitignore from the root
+# https://github.com/johno/actions-push-subdirectories/issues/1
+node_modules


### PR DESCRIPTION
This prevents actions-push-subdirectories from pushing node_modules to robinmetral/gatsby-starter-oss in the publish-starter action. There is an open issue to solve this at https://github.com/johno/actions-push-subdirectories/issues/1.