### PR TITLE
feat: make it easy to add the github token env var

### DIFF
--- a/examples/gatsby-starter-oss/.env.example
+++ b/examples/gatsby-starter-oss/.env.example
@@ -1,0 +1,2 @@
+# add a github token below and rename this file `.env`
+GITHUB_TOKEN=YOUR_TOKEN_GOES_HERE

--- a/examples/gatsby-starter-oss/.gitignore
+++ b/examples/gatsby-starter-oss/.gitignore
@@ -1,3 +1,4 @@
 # ignore node_modules while the publish-starter action doesn't pull .gitignore from the root
 # https://github.com/johno/actions-push-subdirectories/issues/1
 node_modules
+.env

--- a/examples/gatsby-starter-oss/README.md
+++ b/examples/gatsby-starter-oss/README.md
@@ -4,17 +4,25 @@ A Gatsby starter using [`gatsby-theme-oss`](https://github.com/robinmetral/gatsb
 
 ## Getting started
 
-### With the Gatsby CLI
+### Clone
+
+#### With the Gatsby CLI
 
 ```
 gatsby new my-gatsby-site https://github.com/robinmetral/gatsby-starter-oss
 ```
 
-### On GitHub
+#### On GitHub
 
 Create a new repo from `gatsby-starter-oss` with the GitHub
 `Use this template` button, or
 [click here](https://github.com/robinmetral/gatsby-starter-oss/generate).
+
+### Add a GitHub token
+
+The starter expects a GitHub token (with `repo` access). The default config expects it in the `GITHUB_TOKEN` [environment variable](https://www.gatsbyjs.org/docs/environment-variables/).
+
+You can simply create a token [here](https://github.com/settings/tokens), add it to the `.env-example` file, rename the file `.env`, and you're ready to go!
 
 ## Features
 


### PR DESCRIPTION
- add a section to the README in getting started
- add a sample .env file under .env.example
- pre-ignore .env in .gitignore