### PR TITLE
chore: move away from renovate base config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,12 +1,13 @@
 {
   extends: [
-    "config:base",
     // add [skip ci] to commit body when pinning
     ":pinSkipCi",
   ],
-  // config:base ignores the `examples` path by default
-  // an empty ignorePaths array overrides it to enable updates for `examples/gatsby-starter-oss`
-  ignorePaths: [],
+  // run for 6 hours on Monday mornings
+  schedule: "before 6am on Monday",
+  // ignore node_modules
+  // the :ignoreModulesAndTests preset doesn't work here because it also ignores examples
+  ignorePaths: ["**/node_modules/**"],
   // bump versions instead of widening the range
   // https://docs.renovatebot.com/configuration-options/#rangestrategy
   rangeStrategy: "bump",
@@ -23,20 +24,28 @@
   // https://docs.renovatebot.com/configuration-options/#groupname
   packageRules: [
     {
-      packagePatterns: ["^eslint", "prettier"],
-      groupName: "Linting",
+      extends: "monorepo:react",
+      groupName: "react monorepo",
     },
     {
-      packagePatterns: ["gatsby"],
-      groupName: "Gatsby",
+      extends: "monorepo:gatsby",
+      groupName: "gatsby monorepo",
+    },
+    {
+      sourceUrlPrefixes: ["https://github.com/system-ui/theme-ui"],
+      groupName: "theme ui monorepo",
     },
     {
       packagePatterns: ["@testing-library"],
-      groupName: "Testing Library",
+      groupName: "testing library packages",
     },
     {
-      packagePatterns: ["theme-ui", "@theme-ui"],
-      groupName: "Theme UI",
+      extends: "monorepo:jest",
+      groupName: "jest monorepo",
+    },
+    {
+      extends: "monorepo:commitlint",
+      groupName: "commitlint monorepo",
     },
   ],
   // use semantic commits and the parent dir as the scope


### PR DESCRIPTION
Many options in the renovate base config were already being overridden by custom config, or were not relevant to this codebase.

This moves away from the base config and helps better understand the current configuration without the need to refer to the renovate docs.

Key changes:
 - renovate will only be run on Monday mornings
 - the limit on concurrent prs (from the base config) is removed
 - fixes to the ignore path and package groups